### PR TITLE
Update to use multistage docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,20 @@
 # Dockerfile for https://github.com/adnanh/webhook
-
-FROM        alpine:3.6
-
+FROM        golang:alpine3.7 AS build
 MAINTAINER  Almir Dzinovic <almirdzin@gmail.com>
-
-ENV         GOPATH /go
-ENV         SRCPATH ${GOPATH}/src/github.com/adnanh
+WORKDIR     /go/src/github.com/adnanh/webhook
 ENV         WEBHOOK_VERSION 2.6.8
-
-RUN         apk add --update -t build-deps curl go git libc-dev gcc libgcc && \
-            curl -L -o /tmp/webhook-${WEBHOOK_VERSION}.tar.gz https://github.com/adnanh/webhook/archive/${WEBHOOK_VERSION}.tar.gz && \
-            mkdir -p ${SRCPATH} && tar -xvzf /tmp/webhook-${WEBHOOK_VERSION}.tar.gz -C ${SRCPATH} && \
-            mv -f ${SRCPATH}/webhook-* ${SRCPATH}/webhook && \
-            cd ${SRCPATH}/webhook && go get -d && go build -o /usr/local/bin/webhook && \
+RUN         apk add --update -t build-deps curl libc-dev gcc libgcc
+RUN         curl -L --silent -o webhook.tar.gz https://github.com/adnanh/webhook/archive/${WEBHOOK_VERSION}.tar.gz && \
+            tar -xzf webhook.tar.gz --strip 1 &&  \
+            go get -d && \
+            go build -o /usr/local/bin/webhook && \
             apk del --purge build-deps && \
             rm -rf /var/cache/apk/* && \
-            rm -rf ${GOPATH}
+            rm -rf /go
 
+FROM        alpine:3.7
+COPY        --from=build /usr/local/bin/webhook /usr/local/bin/webhook
+COPY        hooks.json.example /etc/webhook/hooks.json
 EXPOSE      9000
-
 ENTRYPOINT  ["/usr/local/bin/webhook"]
+CMD         ["-verbose", "-hooks=/etc/webhook/hooks.json", "-hotreload"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,5 @@ RUN         curl -L --silent -o webhook.tar.gz https://github.com/adnanh/webhook
 
 FROM        alpine:3.7
 COPY        --from=build /usr/local/bin/webhook /usr/local/bin/webhook
-COPY        hooks.json.example /etc/webhook/hooks.json
 EXPOSE      9000
 ENTRYPOINT  ["/usr/local/bin/webhook"]
-CMD         ["-verbose", "-hooks=/etc/webhook/hooks.json", "-hotreload"]


### PR DESCRIPTION
The current docker image results in a ~460MB image when building the artifact. 
We can use [multi stage builds](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#use-multi-stage-builds) to deliver final products built within Alpine at around ~15MB, matching the results in docker hub. 