### PR TITLE
Extending auto-update-repo to deploy automatically on push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+jobs:
+  build:
+    machine: true
+    environment:
+      - IMAGE: "webhook"
+      - WEBHOOK_VERSION: "2.6.8"
+    steps:
+      - checkout
+      - run:
+          name: Log in to docker hub
+          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run:
+          name: Build image from Dockerfile
+          command: docker build -t $DOCKER_USER/$IMAGE:$WEBHOOK_VERSION .
+      - run:
+          name: Push image to docker hub
+          command: docker push $DOCKER_USER/$IMAGE:$WEBHOOK_VERSION

--- a/auto-update-repo/update-repo.sh
+++ b/auto-update-repo/update-repo.sh
@@ -21,7 +21,8 @@ check_and_update() {
 
   # Compare releases and update Dockerfile in case they differ
   if [[ "${LOCAL_RELEASE}" != "${LATEST_RELEASE}" ]] && [[ -n ${LATEST_RELEASE} ]]; then
-    sed -i "s/WEBHOOK_VERSION ${LOCAL_RELEASE}/WEBHOOK_VERSION ${LATEST_RELEASE}/g" ${SCRIPTPATH}/../Dockerfile
+    sed -i "s/WEBHOOK_VERSION.*/WEBHOOK_VERSION ${LATEST_RELEASE}/g" ${SCRIPTPATH}/../Dockerfile
+    sed -i "s/WEBHOOK_VERSION.*/WEBHOOK_VERSION: \"${LATEST_RELEASE}\"/g" ${SCRIPTPATH}/../.circleci/config.yml
     git commit -am "- bump webhook version to ${LATEST_RELEASE}"
     git push origin ${CURBRANCH} && \
     curl -s -X POST -H "Content-Type: application/json" \


### PR DESCRIPTION
I've looked over the cron job, and that looks like an interesting strategy to automatically update a Dockerfile. I don't see anywhere that pushes the container to the public so thats likely still manual. I've added a CircleCI job to perform Continuous Delivery, every push will trigger a push to docker hub. 

You will need to enable CircleCI on github (It's free) and add 2 Environment Variables to your build settings in CircleCi. 

- DOCKER_PASS
- DOCKER_USER

You can see it working the CircleCI results [here](https://circleci.com/gh/stefancrain/docker-webhook/10) and the published artifact [here](https://hub.docker.com/r/stefancrain/webhook/tags/)