### PR TITLE
fix mounting /etc/webhook volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,6 @@ RUN         curl -L --silent -o webhook.tar.gz https://github.com/adnanh/webhook
 
 FROM        alpine:3.7
 COPY        --from=build /usr/local/bin/webhook /usr/local/bin/webhook
+VOLUME      ["/etc/webhook"]
 EXPOSE      9000
 ENTRYPOINT  ["/usr/local/bin/webhook"]


### PR DESCRIPTION
Current following the guide to get started, you will get this error:

```bash
docker run --rm -p 9001:9000 --name=webhook -v $pwd:/etc/webhook almir/webhook -verbose -hooks=/etc/webhook/hooks.json -hotreload
[webhook] 2018/10/27 08:46:17 version 2.6.8 starting
[webhook] 2018/10/27 08:46:17 setting up os signal watcher
[webhook] 2018/10/27 08:46:17 attempting to load hooks from /etc/webhook/hooks.json
[webhook] 2018/10/27 08:46:17 couldn't load hooks from file! open /etc/webhook/hooks.json: no such file or directory
[webhook] 2018/10/27 08:46:17 os signal watcher ready
[webhook] 2018/10/27 08:46:17 serving hooks on http://0.0.0.0:9000/hooks/{id}
```
The volume is missing for mounting.
